### PR TITLE
Added beforeDestroy to ensure menu is closed

### DIFF
--- a/src/ctx-menu.js
+++ b/src/ctx-menu.js
@@ -104,5 +104,8 @@ export default {
         'left': (this.ctxLeft || 0) + 'px'
       }
     }
+  },
+  beforeDestroy() {
+    this.bodyClickListener.stop();
   }
 }


### PR DESCRIPTION
Found that is menu is shown, and user click Back button on browser, this is not detected as a clickOutside, and so the bodyClicklListener is still active and it prevents me from clicking on other router-links.
Adding the beforeDestroy  fixed that