### PR TITLE
Fix demo Vue CDN URL

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -80,7 +80,7 @@
         <li class="ctx-item" @click="logClick($event, menuData)">add to log</li>
     </context-menu>
   </div>
-  <script src="//unpkg.com/vue/dist/vue.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/vue@2.7.0/dist/vue.js"></script>
   <script src="vue-context-menu.js"></script>
   <script>
   // install globally as <context-menu>


### PR DESCRIPTION
The previous `src` of the Vue CDN script was 404.

![2022-07-07 16_49_52-Window](https://user-images.githubusercontent.com/59508036/177771769-c4872ac7-52dc-485d-9def-e805fd7d66b1.png)
![2022-07-07 16_51_04-Window](https://user-images.githubusercontent.com/59508036/177771883-a2a17343-71c6-4278-bead-12cc3848accf.png)

